### PR TITLE
RecyclerView with CardView layout implementation for all fragments

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     implementation 'com.android.support:support-v4:27.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'

--- a/app/src/main/java/com/example/android/audacity/DashboardActivity.java
+++ b/app/src/main/java/com/example/android/audacity/DashboardActivity.java
@@ -35,11 +35,14 @@ public class DashboardActivity extends AppCompatActivity implements NavigationVi
     private FirebaseAuth mFirebaseAuth;
     private GoogleSignInOptions gso;
     private GoogleSignInClient mGoogleSignInClient;
+    public static String[] mCategoriesArray;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_dashboard);
+
+        mCategoriesArray = getResources().getStringArray(R.array.categories);
 
         mFirebaseAuth = FirebaseAuth.getInstance();
         if (mFirebaseAuth == null) {

--- a/app/src/main/java/com/example/android/audacity/fragments/ChallengesFragment.java
+++ b/app/src/main/java/com/example/android/audacity/fragments/ChallengesFragment.java
@@ -2,29 +2,64 @@ package com.example.android.audacity.fragments;
 
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.example.android.audacity.R;
+import com.example.android.audacity.models.ChallengesModel;
+import com.example.android.audacity.utils.ChallengesAdapter;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * A simple {@link Fragment} subclass.
  */
 public class ChallengesFragment extends Fragment {
 
+    private ArrayList<ChallengesModel> mChallengesList;
+    private RecyclerView mRecyclerView;
+
 
     public ChallengesFragment() {
         // Required empty public constructor
+        setUpChallengesData();
     }
 
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_challenges, container, false);
+        View challengeFragment = inflater.inflate(R.layout.fragment_challenges, container,
+                false);
+        ChallengesAdapter challengeAdapter = new ChallengesAdapter(getContext(), mChallengesList);
+        mRecyclerView = challengeFragment.findViewById(R.id.recycler_view);
+        //set up layout for RecyclerView
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(getContext(),
+                LinearLayoutManager.VERTICAL, false));
+        mRecyclerView.setHasFixedSize(true);
+        //set the data adapter
+        mRecyclerView.setAdapter(challengeAdapter);
+        return challengeFragment;
+    }
+
+    //dummy data setup which will be replaced with data from DB later
+    private void setUpChallengesData() {
+        mChallengesList = new ArrayList<>();
+        for(int i=0; i<10; i++) {
+            mChallengesList.add(new ChallengesModel(R.mipmap.ic_launcher_round,
+                    "Challenge Name", "Mod Name",
+                    "End Date " + new SimpleDateFormat("dd-MM-yyyy",
+                            Locale.getDefault()).format(new Date())));
+        }
     }
 
 }

--- a/app/src/main/java/com/example/android/audacity/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/android/audacity/fragments/HomeFragment.java
@@ -2,29 +2,64 @@ package com.example.android.audacity.fragments;
 
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.example.android.audacity.DashboardActivity;
 import com.example.android.audacity.R;
+import com.example.android.audacity.models.HomeModel;
+import com.example.android.audacity.utils.HomeAdapter;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * A simple {@link Fragment} subclass.
  */
 public class HomeFragment extends Fragment {
 
+    private ArrayList<HomeModel> mHomeItemsList;
+    private RecyclerView mRecyclerView;
+
 
     public HomeFragment() {
         // Required empty public constructor
+        setUpHomeData();
     }
 
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_home, container, false);
+        View homeFragment = inflater.inflate(R.layout.fragment_home, container, false);
+        HomeAdapter homeAdapter = new HomeAdapter(getContext(), mHomeItemsList);
+        mRecyclerView = homeFragment.findViewById(R.id.recycler_view);
+        //set up layout for RecyclerView
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(getContext(),
+                LinearLayoutManager.VERTICAL, false));
+        mRecyclerView.setHasFixedSize(true);
+        //set the data adapter
+        mRecyclerView.setAdapter(homeAdapter);
+        return homeFragment;
+    }
+
+    private void setUpHomeData() {
+        mHomeItemsList = new ArrayList<>();
+        String[] categories = DashboardActivity.mCategoriesArray;
+        for(int i = 0; i<categories.length; i++) {
+            mHomeItemsList.add(new HomeModel(categories[i], R.mipmap.ic_launcher_round,
+                    "Header Text", "Sub Text",
+                    "Date " + new SimpleDateFormat("dd-MM-yyyy",
+                            Locale.getDefault()).format(new Date())));
+        }
     }
 
 }

--- a/app/src/main/java/com/example/android/audacity/fragments/HottestAppFragment.java
+++ b/app/src/main/java/com/example/android/audacity/fragments/HottestAppFragment.java
@@ -2,29 +2,64 @@ package com.example.android.audacity.fragments;
 
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.example.android.audacity.R;
+import com.example.android.audacity.models.HottestAppModel;
+import com.example.android.audacity.utils.HottestAppAdapter;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * A simple {@link Fragment} subclass.
  */
 public class HottestAppFragment extends Fragment {
 
+    private ArrayList<HottestAppModel> mAppList;
+    private RecyclerView mRecyclerView;
+
 
     public HottestAppFragment() {
         // Required empty public constructor
+        setUpHottestAppData();
     }
 
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_hottest_app, container, false);
+        View appFragment =  inflater.inflate(R.layout.fragment_hottest_app, container,
+                false);
+        HottestAppAdapter appAdapter = new HottestAppAdapter(getContext(), mAppList);
+        mRecyclerView = appFragment.findViewById(R.id.recycler_view);
+        //set up layout for RecyclerView
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(getContext(),
+                LinearLayoutManager.VERTICAL, false));
+        mRecyclerView.setHasFixedSize(true);
+        //set the data adapter
+        mRecyclerView.setAdapter(appAdapter);
+        return appFragment;
+    }
+
+    //dummy data setup which will be replaced with data from DB later
+    private void setUpHottestAppData() {
+        mAppList = new ArrayList<>();
+        for(int i=0; i<10; i++) {
+            mAppList.add(new HottestAppModel(R.mipmap.ic_launcher_round,
+                    "App Name", "Student Name",
+                    "Posted Date " + new SimpleDateFormat("dd-MM-yyyy",
+                            Locale.getDefault()).format(new Date())));
+        }
     }
 
 }

--- a/app/src/main/java/com/example/android/audacity/fragments/QuizzesFragment.java
+++ b/app/src/main/java/com/example/android/audacity/fragments/QuizzesFragment.java
@@ -2,30 +2,63 @@ package com.example.android.audacity.fragments;
 
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-
 import com.example.android.audacity.R;
+import com.example.android.audacity.models.QuizzesModel;
+import com.example.android.audacity.utils.QuizzesAdapter;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * A simple {@link Fragment} subclass.
  */
 public class QuizzesFragment extends Fragment {
 
+    private ArrayList<QuizzesModel> mQuizList;
+    private RecyclerView mRecyclerView;
+
 
     public QuizzesFragment() {
         // Required empty public constructor
+        setUpQuizzesData();
     }
 
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_quizzes, container, false);
+        View quizFragment = inflater.inflate(R.layout.fragment_quizzes, container, false);
+        QuizzesAdapter quizAdapter = new QuizzesAdapter(getContext(), mQuizList);
+        mRecyclerView = quizFragment.findViewById(R.id.recycler_view);
+        //set up layout for RecyclerView
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(getContext(),
+                LinearLayoutManager.VERTICAL, false));
+        mRecyclerView.setHasFixedSize(true);
+        //set the data adapter
+        mRecyclerView.setAdapter(quizAdapter);
+        return quizFragment;
+    }
+
+    //dummy data setup which will be replaced with data from DB later
+    private void setUpQuizzesData() {
+        mQuizList = new ArrayList<>();
+        for(int i=0; i<10; i++) {
+            mQuizList.add(new QuizzesModel(R.mipmap.ic_launcher_round,
+                    "Quiz Name", "Mod Name",
+                    "End Date " + new SimpleDateFormat("dd-MM-yyyy",
+                            Locale.getDefault()).format(new Date())));
+        }
     }
 
 }

--- a/app/src/main/java/com/example/android/audacity/fragments/ResultsFragment.java
+++ b/app/src/main/java/com/example/android/audacity/fragments/ResultsFragment.java
@@ -2,29 +2,63 @@ package com.example.android.audacity.fragments;
 
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.example.android.audacity.R;
+import com.example.android.audacity.models.ResultsModel;
+import com.example.android.audacity.utils.ResultsAdapter;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * A simple {@link Fragment} subclass.
  */
 public class ResultsFragment extends Fragment {
 
+    private ArrayList<ResultsModel> mChallengesList;
+    private RecyclerView mRecyclerView;
+
 
     public ResultsFragment() {
         // Required empty public constructor
+        setUpResultsData();
     }
 
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_results, container, false);
+        View resultFragment = inflater.inflate(R.layout.fragment_results, container, false);
+        ResultsAdapter resultAdapter = new ResultsAdapter(getContext(), mChallengesList);
+        mRecyclerView = resultFragment.findViewById(R.id.recycler_view);
+        //set up layout for RecyclerView
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(getContext(),
+                LinearLayoutManager.VERTICAL, false));
+        mRecyclerView.setHasFixedSize(true);
+        //set the data adapter
+        mRecyclerView.setAdapter(resultAdapter);
+        return resultFragment;
+    }
+
+    //dummy data setup which will be replaced with data from DB later
+    private void setUpResultsData() {
+        mChallengesList = new ArrayList<>();
+        for(int i=0; i<10; i++) {
+            mChallengesList.add(new ResultsModel(R.mipmap.ic_launcher_round,
+                    "Quiz/Challenge Name", "Mod Name",
+                    new SimpleDateFormat("dd-MM-yyyy",
+                            Locale.getDefault()).format(new Date())));
+        }
     }
 
 }

--- a/app/src/main/java/com/example/android/audacity/models/ChallengesModel.java
+++ b/app/src/main/java/com/example/android/audacity/models/ChallengesModel.java
@@ -1,0 +1,32 @@
+package com.example.android.audacity.models;
+
+public class ChallengesModel {
+
+    private int mProfileImageId;
+    private String mChallengeName;
+    private String mModeratorName;
+    private String mEndDate;
+
+    public ChallengesModel(int profileImageId, String challengeName, String moderatorName, String endDate) {
+        this.mProfileImageId = profileImageId;
+        this.mChallengeName = challengeName;
+        this.mModeratorName = moderatorName;
+        this.mEndDate = endDate;
+    }
+
+    public int getmProfileImageId() {
+        return mProfileImageId;
+    }
+
+    public String getmChallengeName() {
+        return mChallengeName;
+    }
+
+    public String getmModeratorName() {
+        return mModeratorName;
+    }
+
+    public String getmEndDate() {
+        return mEndDate;
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/models/HomeModel.java
+++ b/app/src/main/java/com/example/android/audacity/models/HomeModel.java
@@ -1,0 +1,38 @@
+package com.example.android.audacity.models;
+
+public class HomeModel {
+
+    private String mCategory;
+    private int mProfileImageId;
+    private String mHeaderText;
+    private String mSubText;
+    private String mDateText;
+
+    public HomeModel(String category, int profileImageId, String headerText, String subText, String dateText) {
+        this.mCategory = category;
+        this.mProfileImageId = profileImageId;
+        this.mHeaderText = headerText;
+        this.mSubText = subText;
+        this.mDateText = dateText;
+    }
+
+    public String getmCategory() {
+        return mCategory;
+    }
+
+    public int getmProfileImageId() {
+        return mProfileImageId;
+    }
+
+    public String getmHeaderText() {
+        return mHeaderText;
+    }
+
+    public String getmSubText() {
+        return mSubText;
+    }
+
+    public String getmDateText() {
+        return mDateText;
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/models/HottestAppModel.java
+++ b/app/src/main/java/com/example/android/audacity/models/HottestAppModel.java
@@ -1,0 +1,32 @@
+package com.example.android.audacity.models;
+
+public class HottestAppModel {
+
+    private int mProfileImageId;
+    private String mAppName;
+    private String mStudentName;
+    private String mPostedDate;
+
+    public HottestAppModel(int profileImageId, String appName, String studentName, String postedDate) {
+        this.mProfileImageId = profileImageId;
+        this.mAppName = appName;
+        this.mStudentName = studentName;
+        this.mPostedDate = postedDate;
+    }
+
+    public int getmProfileImageId() {
+        return mProfileImageId;
+    }
+
+    public String getmAppName() {
+        return mAppName;
+    }
+
+    public String getmStudentName() {
+        return mStudentName;
+    }
+
+    public String getmPostedDate() {
+        return mPostedDate;
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/models/QuizzesModel.java
+++ b/app/src/main/java/com/example/android/audacity/models/QuizzesModel.java
@@ -1,0 +1,32 @@
+package com.example.android.audacity.models;
+
+public class QuizzesModel {
+
+    private int mProfileImageId;
+    private String mQuizName;
+    private String mModeratorName;
+    private String mEndDate;
+
+    public QuizzesModel(int profileImageId, String quizName, String moderatorName, String endDate) {
+        this.mProfileImageId = profileImageId;
+        this.mQuizName = quizName;
+        this.mModeratorName = moderatorName;
+        this.mEndDate = endDate;
+    }
+
+    public int getmProfileImageId() {
+        return mProfileImageId;
+    }
+
+    public String getmQuizName() {
+        return mQuizName;
+    }
+
+    public String getmModeratorName() {
+        return mModeratorName;
+    }
+
+    public String getmEndDate() {
+        return mEndDate;
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/models/ResultsModel.java
+++ b/app/src/main/java/com/example/android/audacity/models/ResultsModel.java
@@ -1,0 +1,32 @@
+package com.example.android.audacity.models;
+
+public class ResultsModel {
+
+    private int mProfileImageId;
+    private String mQuiz_ChallengeName;
+    private String mModeratorName;
+    private String mPostedDate;
+
+    public ResultsModel(int profileImageId, String quiz_challengeName, String moderatorName, String postedDate) {
+        this.mProfileImageId = profileImageId;
+        this.mQuiz_ChallengeName = quiz_challengeName;
+        this.mModeratorName = moderatorName;
+        this.mPostedDate = postedDate;
+    }
+
+    public int getmProfileImageId() {
+        return mProfileImageId;
+    }
+
+    public String getmQuiz_ChallengeName() {
+        return mQuiz_ChallengeName;
+    }
+
+    public String getmModeratorName() {
+        return mModeratorName;
+    }
+
+    public String getmPostedDate() {
+        return mPostedDate;
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/ChallengesAdapter.java
+++ b/app/src/main/java/com/example/android/audacity/utils/ChallengesAdapter.java
@@ -1,0 +1,46 @@
+package com.example.android.audacity.utils;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.android.audacity.R;
+import com.example.android.audacity.models.ChallengesModel;
+
+import java.util.ArrayList;
+
+public class ChallengesAdapter extends RecyclerView.Adapter<ChallengesViewHolder> {
+
+    private Context mContext;
+    private ArrayList<ChallengesModel> mChallengesList;
+
+    public ChallengesAdapter(Context context, ArrayList<ChallengesModel> challengesList) {
+        this.mContext = context;
+        this.mChallengesList = challengesList;
+    }
+
+    @NonNull
+    @Override
+    public ChallengesViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View challengeView = LayoutInflater.from(mContext)
+                .inflate(R.layout.individual_fragment_item_layout, parent, false);
+        return new ChallengesViewHolder(challengeView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ChallengesViewHolder holder, int position) {
+        ChallengesModel challengesModel = mChallengesList.get(position);
+        holder.mProfileImage.setBackgroundResource(challengesModel.getmProfileImageId());
+        holder.mChallengeName.setText(challengesModel.getmChallengeName());
+        holder.mModeratorName.setText(challengesModel.getmModeratorName());
+        holder.mEndDate.setText(challengesModel.getmEndDate());
+    }
+
+    @Override
+    public int getItemCount() {
+        return mChallengesList.size();
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/ChallengesViewHolder.java
+++ b/app/src/main/java/com/example/android/audacity/utils/ChallengesViewHolder.java
@@ -1,0 +1,24 @@
+package com.example.android.audacity.utils;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.example.android.audacity.R;
+
+public class ChallengesViewHolder extends RecyclerView.ViewHolder {
+
+    ImageView mProfileImage;
+    TextView mChallengeName;
+    TextView mModeratorName;
+    TextView mEndDate;
+
+    ChallengesViewHolder(View itemView) {
+        super(itemView);
+        mProfileImage = itemView.findViewById(R.id.profile_image);
+        mChallengeName = itemView.findViewById(R.id.header_text);
+        mModeratorName = itemView.findViewById(R.id.sub_text);
+        mEndDate = itemView.findViewById(R.id.date_text);
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/HomeAdapter.java
+++ b/app/src/main/java/com/example/android/audacity/utils/HomeAdapter.java
@@ -1,0 +1,47 @@
+package com.example.android.audacity.utils;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.android.audacity.R;
+import com.example.android.audacity.models.HomeModel;
+
+import java.util.ArrayList;
+
+public class HomeAdapter extends RecyclerView.Adapter<HomeViewHolder> {
+
+    private Context mContext;
+    private ArrayList<HomeModel> mHomeItemsList;
+
+    public HomeAdapter(Context context, ArrayList<HomeModel> homeItemsList) {
+        this.mContext = context;
+        this.mHomeItemsList = homeItemsList;
+    }
+
+    @NonNull
+    @Override
+    public HomeViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View homeView = LayoutInflater.from(mContext)
+                .inflate(R.layout.home_fragment_item_layout, parent, false);
+        return new HomeViewHolder(homeView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull HomeViewHolder holder, int position) {
+        HomeModel homeModel = mHomeItemsList.get(position);
+        holder.mCategory.setText(homeModel.getmCategory());
+        holder.mProfileImage.setBackgroundResource(homeModel.getmProfileImageId());
+        holder.mHeaderText.setText(homeModel.getmHeaderText());
+        holder.mSubText.setText(homeModel.getmSubText());
+        holder.mDateText.setText(homeModel.getmDateText());
+    }
+
+    @Override
+    public int getItemCount() {
+        return mHomeItemsList.size();
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/HomeViewHolder.java
+++ b/app/src/main/java/com/example/android/audacity/utils/HomeViewHolder.java
@@ -1,0 +1,26 @@
+package com.example.android.audacity.utils;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.example.android.audacity.R;
+
+public class HomeViewHolder extends RecyclerView.ViewHolder {
+
+    TextView mCategory;
+    ImageView mProfileImage;
+    TextView mHeaderText;
+    TextView mSubText;
+    TextView mDateText;
+
+    HomeViewHolder(View itemView) {
+        super(itemView);
+        mCategory = itemView.findViewById(R.id.category);
+        mProfileImage = itemView.findViewById(R.id.profile_image);
+        mHeaderText = itemView.findViewById(R.id.header_text);
+        mSubText = itemView.findViewById(R.id.sub_text);
+        mDateText = itemView.findViewById(R.id.date_text);
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/HottestAppAdapter.java
+++ b/app/src/main/java/com/example/android/audacity/utils/HottestAppAdapter.java
@@ -1,0 +1,46 @@
+package com.example.android.audacity.utils;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.android.audacity.R;
+import com.example.android.audacity.models.HottestAppModel;
+
+import java.util.ArrayList;
+
+public class HottestAppAdapter extends RecyclerView.Adapter<HottestAppViewHolder> {
+
+    private Context mContext;
+    private ArrayList<HottestAppModel> mAppList;
+
+    public HottestAppAdapter(Context context, ArrayList<HottestAppModel> appList) {
+        this.mContext = context;
+        this.mAppList = appList;
+    }
+
+    @NonNull
+    @Override
+    public HottestAppViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View appView = LayoutInflater.from(mContext)
+                .inflate(R.layout.individual_fragment_item_layout, parent, false);
+        return new HottestAppViewHolder(appView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull HottestAppViewHolder holder, int position) {
+        HottestAppModel appModel = mAppList.get(position);
+        holder.mProfileImage.setBackgroundResource(appModel.getmProfileImageId());
+        holder.mAppName.setText(appModel.getmAppName());
+        holder.mStudentName.setText(appModel.getmStudentName());
+        holder.mPostedDate.setText(appModel.getmPostedDate());
+    }
+
+    @Override
+    public int getItemCount() {
+        return mAppList.size();
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/HottestAppViewHolder.java
+++ b/app/src/main/java/com/example/android/audacity/utils/HottestAppViewHolder.java
@@ -1,0 +1,24 @@
+package com.example.android.audacity.utils;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.example.android.audacity.R;
+
+public class HottestAppViewHolder extends RecyclerView.ViewHolder {
+
+    ImageView mProfileImage;
+    TextView mAppName;
+    TextView mStudentName;
+    TextView mPostedDate;
+
+    HottestAppViewHolder(View itemView) {
+        super(itemView);
+        mProfileImage = itemView.findViewById(R.id.profile_image);
+        mAppName = itemView.findViewById(R.id.header_text);
+        mStudentName = itemView.findViewById(R.id.sub_text);
+        mPostedDate = itemView.findViewById(R.id.date_text);
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/QuizzesAdapter.java
+++ b/app/src/main/java/com/example/android/audacity/utils/QuizzesAdapter.java
@@ -1,0 +1,46 @@
+package com.example.android.audacity.utils;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.android.audacity.R;
+import com.example.android.audacity.models.QuizzesModel;
+
+import java.util.ArrayList;
+
+public class QuizzesAdapter extends RecyclerView.Adapter<QuizzesViewHolder> {
+
+    private Context mContext;
+    private ArrayList<QuizzesModel> mQuizList;
+
+    public QuizzesAdapter(Context context, ArrayList<QuizzesModel> quizList) {
+        this.mContext = context;
+        this.mQuizList = quizList;
+    }
+
+    @NonNull
+    @Override
+    public QuizzesViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View quizView = LayoutInflater.from(mContext)
+                .inflate(R.layout.individual_fragment_item_layout, parent, false);
+        return new QuizzesViewHolder(quizView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull QuizzesViewHolder holder, int position) {
+        QuizzesModel quizModel = mQuizList.get(position);
+        holder.mProfileImage.setBackgroundResource(quizModel.getmProfileImageId());
+        holder.mQuizName.setText(quizModel.getmQuizName());
+        holder.mModeratorName.setText(quizModel.getmModeratorName());
+        holder.mEndDate.setText(quizModel.getmEndDate());
+    }
+
+    @Override
+    public int getItemCount() {
+        return mQuizList.size();
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/QuizzesViewHolder.java
+++ b/app/src/main/java/com/example/android/audacity/utils/QuizzesViewHolder.java
@@ -1,0 +1,24 @@
+package com.example.android.audacity.utils;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.example.android.audacity.R;
+
+public class QuizzesViewHolder extends RecyclerView.ViewHolder {
+
+    ImageView mProfileImage;
+    TextView mQuizName;
+    TextView mModeratorName;
+    TextView mEndDate;
+
+    QuizzesViewHolder(View itemView) {
+        super(itemView);
+        mProfileImage = itemView.findViewById(R.id.profile_image);
+        mQuizName = itemView.findViewById(R.id.header_text);
+        mModeratorName = itemView.findViewById(R.id.sub_text);
+        mEndDate = itemView.findViewById(R.id.date_text);
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/ResultsAdapter.java
+++ b/app/src/main/java/com/example/android/audacity/utils/ResultsAdapter.java
@@ -1,0 +1,46 @@
+package com.example.android.audacity.utils;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.android.audacity.R;
+import com.example.android.audacity.models.ResultsModel;
+
+import java.util.ArrayList;
+
+public class ResultsAdapter extends RecyclerView.Adapter<ResultsViewHolder> {
+
+    private Context mContext;
+    private ArrayList<ResultsModel> mResultsList;
+
+    public ResultsAdapter(Context context, ArrayList<ResultsModel> resultsList) {
+        this.mContext = context;
+        this.mResultsList = resultsList;
+    }
+
+    @NonNull
+    @Override
+    public ResultsViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View resultView = LayoutInflater.from(mContext)
+                .inflate(R.layout.individual_fragment_item_layout, parent, false);
+        return new ResultsViewHolder(resultView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ResultsViewHolder holder, int position) {
+        ResultsModel resultModel = mResultsList.get(position);
+        holder.mProfileImage.setBackgroundResource(resultModel.getmProfileImageId());
+        holder.mQuiz_ChallengeName.setText(resultModel.getmQuiz_ChallengeName());
+        holder.mModeratorName.setText(resultModel.getmModeratorName());
+        holder.mPostedDate.setText(resultModel.getmPostedDate());
+    }
+
+    @Override
+    public int getItemCount() {
+        return mResultsList.size();
+    }
+}

--- a/app/src/main/java/com/example/android/audacity/utils/ResultsViewHolder.java
+++ b/app/src/main/java/com/example/android/audacity/utils/ResultsViewHolder.java
@@ -1,0 +1,24 @@
+package com.example.android.audacity.utils;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.example.android.audacity.R;
+
+public class ResultsViewHolder extends RecyclerView.ViewHolder {
+
+    ImageView mProfileImage;
+    TextView mQuiz_ChallengeName;
+    TextView mModeratorName;
+    TextView mPostedDate;
+
+    ResultsViewHolder(View itemView) {
+        super(itemView);
+        mProfileImage = itemView.findViewById(R.id.profile_image);
+        mQuiz_ChallengeName = itemView.findViewById(R.id.header_text);
+        mModeratorName = itemView.findViewById(R.id.sub_text);
+        mPostedDate = itemView.findViewById(R.id.date_text);
+    }
+}

--- a/app/src/main/res/layout/fragment_challenges.xml
+++ b/app/src/main/res/layout/fragment_challenges.xml
@@ -4,10 +4,6 @@
     android:layout_height="match_parent"
     tools:context="com.example.android.audacity.fragments.ChallengesFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+    <include layout="@layout/fragment_recyclerview"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -4,10 +4,6 @@
     android:layout_height="match_parent"
     tools:context="com.example.android.audacity.fragments.HomeFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+    <include layout="@layout/fragment_recyclerview"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_hottest_app.xml
+++ b/app/src/main/res/layout/fragment_hottest_app.xml
@@ -4,10 +4,6 @@
     android:layout_height="match_parent"
     tools:context="com.example.android.audacity.fragments.HottestAppFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+    <include layout="@layout/fragment_recyclerview"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_quizzes.xml
+++ b/app/src/main/res/layout/fragment_quizzes.xml
@@ -4,10 +4,6 @@
     android:layout_height="match_parent"
     tools:context="com.example.android.audacity.fragments.QuizzesFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+    <include layout="@layout/fragment_recyclerview"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_recyclerview.xml
+++ b/app/src/main/res/layout/fragment_recyclerview.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recycler_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+</android.support.v7.widget.RecyclerView>

--- a/app/src/main/res/layout/fragment_results.xml
+++ b/app/src/main/res/layout/fragment_results.xml
@@ -4,10 +4,6 @@
     android:layout_height="match_parent"
     tools:context="com.example.android.audacity.fragments.ResultsFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+    <include layout="@layout/fragment_recyclerview"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/home_fragment_item_layout.xml
+++ b/app/src/main/res/layout/home_fragment_item_layout.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/category"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/dimen_8dp"
+        android:layout_marginStart="@dimen/dimen_16dp"
+        android:layout_marginTop="@dimen/dimen_16dp"
+        android:textColor="@android:color/black"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toStartOf="@+id/view_all"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="TextView" />
+
+    <TextView
+        android:id="@+id/view_all"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/dimen_16dp"
+        android:layout_marginStart="@dimen/dimen_8dp"
+        android:layout_marginTop="@dimen/dimen_16dp"
+        android:text="@string/view_all"
+        android:textAlignment="viewEnd"
+        android:textColor="@android:color/black"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/category"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <android.support.v7.widget.CardView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/dimen_8dp"
+        android:layout_marginStart="@dimen/dimen_8dp"
+        app:cardCornerRadius="@dimen/dimen_8dp"
+        app:cardElevation="@dimen/dimen_4dp"
+        app:cardUseCompatPadding="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/category">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <de.hdodenhof.circleimageview.CircleImageView
+                android:id="@+id/profile_image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/dimen_8dp"
+                android:layout_marginEnd="@dimen/dimen_8dp"
+                android:layout_marginStart="@dimen/dimen_8dp"
+                android:layout_marginTop="@dimen/dimen_8dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:src="@mipmap/ic_launcher_round" />
+
+            <TextView
+                android:id="@+id/header_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/dimen_8dp"
+                android:layout_marginStart="@dimen/dimen_16dp"
+                android:layout_marginTop="@dimen/dimen_8dp"
+                android:textAppearance="@android:style/TextAppearance.Material.Medium"
+                android:textColor="@android:color/black"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toEndOf="@+id/profile_image"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="TextView" />
+
+            <TextView
+                android:id="@+id/sub_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/dimen_8dp"
+                android:layout_marginStart="@dimen/dimen_16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toEndOf="@+id/profile_image"
+                app:layout_constraintTop_toBottomOf="@+id/header_text"
+                tools:text="TextView" />
+
+            <TextView
+                android:id="@+id/date_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/dimen_8dp"
+                android:layout_marginEnd="@dimen/dimen_8dp"
+                android:layout_marginStart="@dimen/dimen_16dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toEndOf="@+id/profile_image"
+                app:layout_constraintTop_toBottomOf="@+id/sub_text"
+                app:layout_constraintVertical_bias="0.0"
+                tools:text="TextView" />
+
+            <android.support.constraint.Barrier
+                android:id="@+id/text_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="end"
+                app:constraint_referenced_ids="header_text,sub_text, date_text" />
+
+            <ImageView
+                android:id="@+id/image_right_arrow"
+                android:layout_width="@dimen/dimen_24dp"
+                android:layout_height="@dimen/dimen_24dp"
+                android:layout_marginBottom="@dimen/dimen_8dp"
+                android:layout_marginEnd="@dimen/dimen_8dp"
+                android:layout_marginStart="@dimen/dimen_8dp"
+                android:layout_marginTop="@dimen/dimen_8dp"
+                android:contentDescription="@string/right_arrow"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toEndOf="@+id/text_barrier"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/next" />
+
+        </android.support.constraint.ConstraintLayout>
+
+    </android.support.v7.widget.CardView>
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/individual_fragment_item_layout.xml
+++ b/app/src/main/res/layout/individual_fragment_item_layout.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="@dimen/dimen_8dp"
+    app:cardElevation="@dimen/dimen_4dp"
+    app:cardPreventCornerOverlap="true"
+    app:cardUseCompatPadding="true">
+
+    <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <de.hdodenhof.circleimageview.CircleImageView
+            android:id="@+id/profile_image"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/dimen_8dp"
+            android:layout_marginEnd="@dimen/dimen_8dp"
+            android:layout_marginStart="@dimen/dimen_8dp"
+            android:layout_marginTop="@dimen/dimen_8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@mipmap/ic_launcher_round" />
+
+        <TextView
+            android:id="@+id/header_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/dimen_8dp"
+            android:layout_marginStart="@dimen/dimen_16dp"
+            android:layout_marginTop="@dimen/dimen_8dp"
+            android:textAppearance="@android:style/TextAppearance.Material.Medium"
+            android:textColor="@android:color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toEndOf="@+id/profile_image"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="TextView" />
+
+        <TextView
+            android:id="@+id/sub_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/dimen_8dp"
+            android:layout_marginStart="@dimen/dimen_16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toEndOf="@+id/profile_image"
+            app:layout_constraintTop_toBottomOf="@+id/header_text"
+            tools:text="TextView" />
+
+        <TextView
+            android:id="@+id/date_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/dimen_8dp"
+            android:layout_marginEnd="@dimen/dimen_8dp"
+            android:layout_marginStart="@dimen/dimen_16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toEndOf="@+id/profile_image"
+            app:layout_constraintTop_toBottomOf="@+id/sub_text"
+            app:layout_constraintVertical_bias="0.0"
+            tools:text="TextView" />
+
+        <android.support.constraint.Barrier
+            android:id="@+id/text_barrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="end"
+            app:constraint_referenced_ids="header_text,sub_text, date_text" />
+
+        <ImageView
+            android:id="@+id/image_right_arrow"
+            android:layout_width="@dimen/dimen_24dp"
+            android:layout_height="@dimen/dimen_24dp"
+            android:layout_marginBottom="@dimen/dimen_8dp"
+            android:layout_marginEnd="@dimen/dimen_8dp"
+            android:layout_marginStart="@dimen/dimen_8dp"
+            android:layout_marginTop="@dimen/dimen_8dp"
+            android:contentDescription="@string/right_arrow"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toEndOf="@+id/text_barrier"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/next" />
+    </android.support.constraint.ConstraintLayout>
+
+</android.support.v7.widget.CardView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -14,4 +14,5 @@
     <dimen name="dimen_4dp">4dp</dimen>
     <dimen name="profile_img_width">64dp</dimen>
     <dimen name="profile_img_height">64dp</dimen>
+    <dimen name="dimen_24dp">24dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,17 @@
 
     <string name="right_arrow">Right Arrow Image</string>
     <string name="view_all">View All</string>
+
+    <!--Categories String Array-->
+    <string name="challenges">Challenges</string>
+    <string name="hottestApp">Hottest App</string>
+    <string name="quizzes">Quizzes</string>
+    <string name="results">Results</string>
+
+    <string-array name="categories">
+        <item>@string/challenges</item>
+        <item>@string/hottestApp</item>
+        <item>@string/quizzes</item>
+        <item>@string/results</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,7 @@
     <string name="settings_title">Settings</string>
     <string name="login_welcome_title" >Welcome to Audacity</string>
     <string name="home">Home</string>
+
+    <string name="right_arrow">Right Arrow Image</string>
+    <string name="view_all">View All</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.google.gms:google-services:3.2.1'
 
 


### PR DESCRIPTION
**Changes made:**
* Add `RecyclerView` and `CardView` layout to all fragments
* Separate **model** classes for items for all fragments (**Home, Challenges, HottestApp, Quizzes, Results**)
* Separate `ViewHolder` and `Adapter` classes for each fragment (`ViewHolder` can be clubbed with `Adapter` if needed)
* Separate methods for handling dummy data in `Fragment` classes 
**============================================================================**
- UI visual polish pending (spacing between cards, text size/styles, image size in cards need to be verified)
- Used **ConstraintLayout** in all layout XML files
- Added comments for `Fragment` classes (comments are not added in `ViewHolder` and `Adapter` classes as they are standard overriden methods - can be added if needed)
- Assuming DB will have stored the dates in `Date` format - used `Date` object for date texts and converted it to `String` for display

A screenshot of `Home` page and `Challenges` page:

![home_page](https://user-images.githubusercontent.com/5392993/39355147-f9002bc8-4a29-11e8-9583-395f82fc166a.jpg)   ![challenges_page](https://user-images.githubusercontent.com/5392993/39355171-0f21dc94-4a2a-11e8-8562-34af5057a638.jpg)

Project mods, kindly review and let me know if any changes are required.