### PR TITLE
removed null pointer exception on recyclerView adapters.

### DIFF
--- a/app/src/main/java/com/example/android/audacity/adapters/ChallengesAdapter.java
+++ b/app/src/main/java/com/example/android/audacity/adapters/ChallengesAdapter.java
@@ -51,7 +51,7 @@ public class ChallengesAdapter extends RecyclerView.Adapter<ChallengesAdapter.Vi
 
     @Override
     public int getItemCount() {
-        return mChallengeData.size();
+        return mChallengeData == null ? 0 : mChallengeData.size();
     }
 
     public class ViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/com/example/android/audacity/adapters/HottestAppAdapter.java
+++ b/app/src/main/java/com/example/android/audacity/adapters/HottestAppAdapter.java
@@ -51,7 +51,7 @@ public class HottestAppAdapter extends RecyclerView.Adapter<HottestAppAdapter.Vi
 
     @Override
     public int getItemCount() {
-        return mHottestAppData.size();
+        return mHottestAppData == null ? 0 : mHottestAppData.size();
     }
 
     public class ViewHolder extends RecyclerView.ViewHolder {


### PR DESCRIPTION
If we pass null to the adapter constructor then the app will crash by throwing NullPointerException.